### PR TITLE
Updated sequence generation.

### DIFF
--- a/getParams.m
+++ b/getParams.m
@@ -24,8 +24,8 @@ expParameters.task = task;
 
 
 %% Debug mode settings
-cfg.debug               = false;  % To test the script
-cfg.testingTranspScreen = false;  % To test with trasparent full size screen 
+cfg.debug               = true;  % To test the script
+cfg.testingTranspScreen = true;  % To test with trasparent full size screen 
 % not sure that's helpful now 
 % what I wanted : in debug mode, transparent monitor, no hide cursor,
 % no blocking keyboard - just play the sounds

--- a/lib/getAllSeqDesign.m
+++ b/lib/getAllSeqDesign.m
@@ -5,10 +5,18 @@ function res = getAllSeqDesign(categA,categB,cfg,expParam)
 % randomized as much as possible
 
 % of course, the possibility of full counterbalancing depends on the number
-% of sequences, steps, sements, and patterns requested in the experiment
+% of sequences, steps, segments, and patterns requested in the experiment
 
-patterns2choose = {categA,categB}; 
 
+% create a separate "reservoir" with available patterns for each segment 
+% (e.g. A, B, B, B)
+[patterns2chooseA{1:cfg.nSegmentA}] = deal(categA); 
+[patterns2chooseB{1:cfg.nSegmentB}] = deal(categB); 
+
+patterns2choose = [patterns2chooseA, patterns2chooseB]; 
+
+
+% allocate restult with dim: sequence x step x segm x pattern
 res = cell(expParam.numSequences, cfg.nStepsPerSequence, cfg.nSegmPerStep, cfg.nPatternPerSegment); 
 
 for seqi=1:expParam.numSequences
@@ -19,40 +27,32 @@ for seqi=1:expParam.numSequences
             
             for pati=1:cfg.nPatternPerSegment
 
-                % Determine which segment category this is (A or B)
-                % (the first 'cfg.nSegmentA' segments will be category A, 
-                % the rest will be category B)
-                if ismember(segmi, [1:cfg.nSegmentA])            
-                    categIdx = 1; 
-                    % check if the category is empty in the avaiable pool of
-                    % patterns
-                    % if so, refill it with the whole set for that category
-                    if isempty(patterns2choose{categIdx})
-                        patterns2choose{categIdx} = categA; 
-                    end
-                else
-                    categIdx = 2; 
-                    % check if the category is empty in the avaiable pool of
-                    % patterns
-                    % if so, refill it with the whole set for that category
-                    if isempty(patterns2choose{categIdx})
-                        patterns2choose{categIdx} = categB; 
+                % check if there are any patterns left in the reservoir for
+                % this segment 
+                % if no, refill it with the whole pattern set for that category
+                if isempty(patterns2choose{segmi})
+                    % Determine which segment category this is (A or B)
+                    % (the first 'cfg.nSegmentA' segments will be category A, 
+                    % the rest will be category B)
+                    if ismember(segmi, [1:cfg.nSegmentA])            
+                        patterns2choose{segmi} = categA; 
+                    else
+                        patterns2choose{segmi} = categB; 
                     end
                 end
                 
                 % pick a pattern from the current category
-                chosenPatIdx = randsample(length(patterns2choose{categIdx}),1); 
+                chosenPatIdx = randsample(length(patterns2choose{segmi}),1); 
                 
                 % get its ID tag
-                chosenPatID = patterns2choose{categIdx}(chosenPatIdx).ID; 
+                chosenPatID = patterns2choose{segmi}(chosenPatIdx).ID; 
                 
                 % write pattern ID to the result
                 % dims: [seq x step x segm x pat]
                 res{seqi,stepi,segmi,pati} = chosenPatID; 
 
                 % remove the picked pattern from the available pool
-                patterns2choose{categIdx}(chosenPatIdx) = []; 
-                
+                patterns2choose{segmi}(chosenPatIdx) = []; 
                 
             end
         end

--- a/lib/getMainExpParameters.m
+++ b/lib/getMainExpParameters.m
@@ -30,7 +30,7 @@ expParam.sequenceDelay = 1;
 expParam.pauseSeq = 1; 
 
 % define ideal number of sequences to be made
-expParam.numSequences = 2; % 6
+expParam.numSequences = 6; % multiples of 3
 
 %% contruct individual sound events (that will make up each pattern)
 
@@ -116,7 +116,7 @@ cfg.interStepInterval = (cfg.interSegmInterval * cfg.nSegmPerStep) + ...
 %% construct whole sequence
 % how many steps are in the whole sequence
 % how many repetition of grouped segment [ABBB] in the whole sequence
-cfg.nStepsPerSequence = 4; % 5
+cfg.nStepsPerSequence = 5; % 5
 
 
 % calculate trial duration (min)


### PR DESCRIPTION
Now each segment in a step has its own 'reservoir' of patterns.
E.g. if each step has segments ABBB, then we would start with one reservoir
containing 30 patterns of category A, and three reservoirs, each containing
patterns of category B.

As we are going over the sequence and randomly picking patterns, we always pick
from the reservoir of the corresponding segment and we don't "put the
pattern back".

If we run out of patterns in a particular reservoir, we reset it to
contain all 30 patterns as at the begnining.

This makes sure each of the patterns is played equaly often in each
segment.

I also updated the parameters (as we discussed on Friday), so the experiment
is counterbalanced.