### PR TITLE
Amplitude logging

### DIFF
--- a/getParams.m
+++ b/getParams.m
@@ -31,7 +31,7 @@ expParameters.equateSoundAmp = 1;
 
 % assuming that participant will do the task with headphones
 cfg.baseAmp = 0.5; 
-
+cfg.PTBInitVolume = 0.3; 
 
 %% BIDS compatible logfile folder
 % by default the data will be stored in an output folder created 

--- a/lib/getMainExpParameters.m
+++ b/lib/getMainExpParameters.m
@@ -128,9 +128,9 @@ cfg.nF0 	= 5; % number of unique F0-values between the limits
 cfg.F0s 	= logspace(log10(cfg.minF0),log10(cfg.maxF0),cfg.nF0); 
 
 if expParam.equateSoundAmp
-    cfg.F0sAmp     = equalizePureTones(cfg.F0s,[], []);
+    cfg.F0sAmpGain     = equalizePureTones(cfg.F0s,[], []);
 else
-    cfg.F0sAmp = ones(1,cfg.nF0);
+    cfg.F0sAmpGain = ones(1,cfg.nF0);
 end
 %================================================================
 % The pitch changes are controlled by the Boolean variables below. 
@@ -177,7 +177,7 @@ cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cf
 % added F0s-amplitude because the relative dB set in volume adjustment in
 % PychPortAudio will be used in the mainExp
 cfg.volumeSettingSound = repmat(makeStimMainExp(ones(1,16), cfg,...
-    cfg.gridIOIs(end), cfg.F0s(end),cfg.F0sAmp(end)), 2,1); 
+    cfg.gridIOIs(end), cfg.F0s(end), cfg.F0sAmpGain(end)*cfg.baseAmp ), 2,1); 
 
 
 

--- a/lib/getMainExpParameters.m
+++ b/lib/getMainExpParameters.m
@@ -127,11 +127,17 @@ cfg.maxF0 	= 900; % maximum possible F0
 cfg.nF0 	= 5; % number of unique F0-values between the limits
 cfg.F0s 	= logspace(log10(cfg.minF0),log10(cfg.maxF0),cfg.nF0); 
 
+% calculate required amplitude gain
 if expParam.equateSoundAmp
-    cfg.F0sAmpGain     = equalizePureTones(cfg.F0s,[], []);
+    cfg.F0sAmpGain = equalizePureTones(cfg.F0s,[], []);
 else
     cfg.F0sAmpGain = ones(1,cfg.nF0);
 end
+
+% use the requested gain of each tone to adjust the base amplitude
+cfg.F0sAmps = cfg.baseAmp * cfg.F0sAmpGain; 
+
+
 %================================================================
 % The pitch changes are controlled by the Boolean variables below. 
 % NOTE: the parameters work together hierarchically, i.e. if you set
@@ -177,7 +183,7 @@ cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cf
 % added F0s-amplitude because the relative dB set in volume adjustment in
 % PychPortAudio will be used in the mainExp
 cfg.volumeSettingSound = repmat(makeStimMainExp(ones(1,16), cfg,...
-    cfg.gridIOIs(end), cfg.F0s(end), cfg.F0sAmpGain(end)*cfg.baseAmp ), 2,1); 
+    cfg.gridIOIs(end), cfg.F0s(end), cfg.F0sAmps(end) ), 2,1); 
 
 
 

--- a/lib/initPTB.m
+++ b/lib/initPTB.m
@@ -127,6 +127,9 @@ AssertOpenGL;
         cfg.pahandle    = PsychPortAudio('Open',cfg.audio.i,1,1,cfg.fs,cfg.audio.channels);
     end
     
+    % set initial PTB volume for safety (participants can adjust this manually
+    % at the begining of the experiment)
+    PsychPortAudio('Volume', cfg.pahandle, cfg.PTBInitVolume); 
     
     cfg.audio.pushsize  = cfg.fs*0.010; %! push N ms only
     cfg.requestoffsettime = 1; % offset 1 sec

--- a/lib/makeSequence.m
+++ b/lib/makeSequence.m
@@ -191,7 +191,7 @@ for stepi=1:cfg.nStepsPerSequence
             end
             
             currF0 = cfg.F0s(currF0idx); 
-            currAmp = cfg.F0sAmp(currF0idx);
+            currAmp = cfg.F0sAmpGain(currF0idx) * cfg.baseAmp;
             
             
             % --------------------------------------------------

--- a/lib/makeSequence.m
+++ b/lib/makeSequence.m
@@ -191,7 +191,7 @@ for stepi=1:cfg.nStepsPerSequence
             end
             
             currF0 = cfg.F0s(currF0idx); 
-            currAmp = cfg.F0sAmpGain(currF0idx) * cfg.baseAmp;
+            currAmp = cfg.F0sAmps(currF0idx);
             
             
             % --------------------------------------------------

--- a/lib/makeStimMainExp.m
+++ b/lib/makeStimMainExp.m
@@ -19,9 +19,9 @@ function [s,env] = makeStimMainExp(pattern, cfg, currGridIOI, currF0,varargin)
 % I added as varargin in case you are using this function somewhere else
 % than the tapMainExperiment
 if nargin<5
-    currAmp = 1* cfg.baseAmp;
+    currAmp = 1;
 else 
-    currAmp = varargin{1} * cfg.baseAmp;
+    currAmp = varargin{1};
 end
 
 
@@ -73,7 +73,7 @@ for cyclei=1:nCycles
     end
 end
 % create carrier 
-s = cfg.toneAmplitude * sin(2*pi*currF0*t); 
+s = sin(2*pi*currF0*t); 
 
 
 % apply envelope to the carrier


### PR DESCRIPTION
I fixed a small thing in makeSequence.m that was from my previous commit
and caused a crash after Ceren's changes with ISO loudness equalization.

I also propose to log the acual matlab tone amplitudes that we're using
for each pattern, as opposed to logging the gain factor that we use to
multiply the baseAmp. The gains can be easily recalculated knowing the
baseAmp value, and this way we can directly see what the matlab
amplitudes are (e.e. that there is no clipping).