### PR TITLE
Updated tone ramp parameters

### DIFF
--- a/lib/getMainExpParameters.m
+++ b/lib/getMainExpParameters.m
@@ -23,21 +23,25 @@ if cfg.debug
 else
     expParam.numSequences = 6;
 end
+
 %% contruct individual sound events (that will make up each pattern)
 
-% define envelope shape of the individual sound event
-% all parameters are defined relative to the gridIOI (as proportion of gridIOI)
-% we don't use minGridIOI to keep everything proportional if the gridIOI is
-% allowed to change across cycles
-% And ramps are applied to each sound event
+% Define envelope shape of the individual sound event. 
+% All parameters are defined in seconds. 
 
-% total sound duration proportion to gridIOI _/```\_  
-cfg.soundDurProp             = 1; % 100% of gridIOI
+% total sound duration _/```\_  
+cfg.soundDur             = 0.190; % s
 % onset ramp duration  _/     
-cfg.eventRampon          = 0.05; % 5% of gridIOI 
+cfg.eventRampon          = 0.010; % s
 % offset ramp duration       \_ 
-cfg.eventRampoff         = 0.020; % 10% of gridIOI
+cfg.eventRampoff         = 0.020; % s
 
+% Make sure the total ramp durations are not longer than tone duration. 
+if (cfg.eventRampon+cfg.eventRampoff) > cfg.soundDur
+    error(sprintf('The summed duration of onset+offset ramps (%g ms) is longer than requensted tone duration (%g ms).',...
+                  (cfg.eventRampon+cfg.eventRampoff)*1e3, ...
+                  cfg.soundDur*1e3)); 
+end
 
 %% construct pattern (smallest item in sequence)
 cfg.nGridPoints = 12; % length(pat_complex(1).pattern)
@@ -60,6 +64,13 @@ cfg.changeGridIOICategory   = 0;
 % change gridIOI for each step
 cfg.changeGridIOIStep       = 0;     
 
+
+% Make sure the tone duration is not longer than smallest gridIOI. 
+if cfg.soundDur >  cfg.minGridIOI
+    error(sprintf('Requested tone duration (%g ms) is longer than shortest gridIOI (%g ms).',...
+                  cfg.soundDur*1e3, ...
+                  cfg.minGridIOI*1e3)); 
+end
 
 %% construct segment
 

--- a/lib/getTrainingParameters.m
+++ b/lib/getTrainingParameters.m
@@ -229,16 +229,33 @@ grahnPatComplex = loadIOIRatiosFromTxt(fullfile('stimuli','Grahn2007_complex.txt
 cfg.grahn.patternSimple = getPatternInfo(grahnPatSimple, 'simple',cfg); 
 cfg.grahn.patternComplex = getPatternInfo(grahnPatComplex, 'complex', cfg); 
 
-% total sound duration proportion to gridIOI _/```\_  
-cfg.grahn.soundDurProp = 1; % 100% of gridIOI
-% onset ramp duration                       _/     
-cfg.grahn.eventRampon = 0.05; % 5% of gridIOI 
-% offset ramp duration                             \_ 
-cfg.grahn.eventRampoff  = 0.020; % 10% of gridIOI
-
 % the grid interval can vary across steps or segments (gridIOI selected 
 % randomly from a set of possible values for each new step or segment) 
 cfg.grahn.gridIOI = 0.190; 
+
+% Define envelope shape of the individual sound event. 
+% All parameters are defined in seconds. 
+
+% total sound duration _/```\_  
+cfg.grahn.soundDur             = 0.190; % s
+% onset ramp duration  _/     
+cfg.grahn.eventRampon          = 0.010; % s
+% offset ramp duration       \_ 
+cfg.grahn.eventRampoff         = 0.020; % s
+
+% Make sure the total ramp durations are not longer than tone duration. 
+if (cfg.grahn.eventRampon+cfg.grahn.eventRampoff) > cfg.grahn.soundDur
+    error(sprintf('The summed duration of onset+offset ramps (%g ms) is longer than requensted tone duration (%g ms).',...
+                  (cfg.grahn.eventRampon+cfg.grahn.eventRampoff)*1e3, ...
+                  cfg.grahn.soundDur*1e3)); 
+end
+% Make sure the tone duration is not longer than smallest gridIOI. 
+if cfg.grahn.soundDur >  cfg.grahn.gridIOI
+    error(sprintf('Requested tone duration (%g ms) is longer than shortest gridIOI (%g ms).',...
+                  cfg.grahn.soundDur*1e3, ...
+                  cfg.grahn.gridIOI*1e3)); 
+end
+
 
 % construct pattern (smallest item in sequence)
 cfg.grahn.nGridPoints = 12; % length(pat_complex(1).pattern)

--- a/lib/makeStimMainExp.m
+++ b/lib/makeStimMainExp.m
@@ -28,13 +28,13 @@ end
 %% make envelope for the individual sound event 
 
 % number of samples for the onset ramp (proportion of gridIOI)
-ramponSamples   = round(currGridIOI * cfg.eventRampon * cfg.fs); 
+ramponSamples   = round(cfg.eventRampon * cfg.fs); 
 
 % number of samples for the offset ramp (proportion of gridIOI)
-rampoffSamples  = round(currGridIOI * cfg.eventRampoff * cfg.fs); 
+rampoffSamples  = round(cfg.eventRampoff * cfg.fs); 
 
 % individual sound event duration defined as proportion of gridIOI
-envEvent = ones(1, round(currGridIOI * cfg.soundDurProp * cfg.fs)); 
+envEvent = ones(1, round(cfg.soundDur * cfg.fs)); 
 
 % make the linear ramps
 envEvent(1:ramponSamples) = envEvent(1:ramponSamples) .* linspace(0,1,ramponSamples); 


### PR DESCRIPTION
There was an error in parameters controlling onset/offest ramps for the
tones in main experiment. Now the values are fixed to 10ms onset ramp,
20ms offset ramp.

Also, originally we were defining these as proportion of gridIOI, but
after thinking about it, I decided to change these parameters into
fixed values in seconds.

This is because if we decided to use very long gridIOIs in the future,
it could lead to very long-duration tones without clear onsets, which is
undesirable.