### PR TITLE
Fixing error-string function

### DIFF
--- a/lib/getErrorStr.m
+++ b/lib/getErrorStr.m
@@ -35,6 +35,12 @@ else
     perfIdx = round( perfLevel * N); 
 end
 
+% if the error was < 0.5, the index is 0, we need to correct it to 1
+if perfIdx == 0
+    perfIdx = 1; 
+end
+
+
 %% threshold
 
 % get threshold they need to achieve to success


### PR DESCRIPTION
When tapping performance was low (<=0.5), the index for the feedback
visual bar was 0 and that caused an error.

Now the script will correct it to 1 (so the # will be at the leftmost
position).