### PR TITLE
block design add

### DIFF
--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -24,7 +24,7 @@ expParam = createFilename(cfg,expParam);
 [cfg,expParam] = makefMRISeqDesign(cfg,expParam);
    
 % get time point at the beginning of the script (machine time)
-expParam.scriptStartTime = GetSecs();
+expParam.timing.scriptStartTime = GetSecs();
 
 %% Experiment
 
@@ -86,15 +86,16 @@ try
     
     
     %% play sequences
-    %    for seqi = 1:expParam.numSequences
+    
+    % take the runNb corresponding sequence
     seqi = expParam.runNb;
+    
     % prep for BIDS saving structures
     currSeq = struct();
     responseEvents = struct();
     
     % construct sequence
     currSeq = makeSequence(cfg,seqi);
-    
     
     % fill the buffer
     PsychPortAudio('FillBuffer', cfg.pahandle, [currSeq.outAudio;currSeq.outAudio]);
@@ -104,8 +105,9 @@ try
         cfg.PTBstartCue, cfg.PTBwaitForDevice);
     
     % save params for later call in BIDS saving
-    expParam.seqi = seqi;
-    expParam.currSeqStartTime = currSeqStartTime;
+    expParam.timing.seqi = seqi;
+    expParam.timing.currSeqStartTime = currSeqStartTime;
+    expParam.timing.experimentStart = expParam.experimentStart;
     
     % ===========================================
     % stimulus save for BIDS
@@ -119,14 +121,14 @@ try
         
         %correcting onsets for fMRI trigger onset
         currSeq(iPattern,1).onset  = currSeq(iPattern,1).onset + ...
-            expParam.currSeqStartTime - expParam.experimentStart;
+            currSeqStartTime - expParam.experimentStart;
         currSeq(iPattern,1).segmentOnset = currSeq(iPattern,1).segmentOnset...
-            + expParam.currSeqStartTime - expParam.experimentStart;
+            + currSeqStartTime - expParam.experimentStart;
         
         %adding compulsory BIDS structures
         currSeq(iPattern,1).trial_type  = 'dummy';
         currSeq(iPattern,1).duration    = 0;
-        %
+        % adding our interest
         currSeq(iPattern,1).sequenceNum = seqi;
         
     end

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -13,13 +13,10 @@ addpath(genpath(fullfile(pwd, 'lib')))
 
 
 % Get parameters
+[cfg,expParam] = getParams('RhythmCategFT','scanner',1);
+%[cfg,expParam] = getParams('RhythmCategBlock');
+%[cfg,expParam] = getParams('PitchFT');
 
-% % %
-% provide here to specifiy the sequence length and/or call getParamsMainExp
-% in here with the arguments for rhythmic sequence, control1 and control2
-% designs
-% % %
-[cfg,expParam] = getParams('tapMainExp');
 
 % set and load all the subject input to run the experiment
 expParam = userInputs(cfg,expParam);
@@ -216,7 +213,7 @@ try
     
     %% wrapping up
     % last screen
-    if expParam.runNb == 666 && expParam.maxfMRIrun
+    if expParam.runNb == 666 || expParam.maxfMRIrun
         displayInstr('DONE. \n\n\nTHANK YOU FOR PARTICIPATING :)\n\n\n Soon we will take you out!',cfg);
     else
         displayInstr('This run is over. We will shortly start the following!',cfg);

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -140,6 +140,7 @@ try
         % ===========================================
         
         % save (machine) onset time for the current sequence
+        % might be irrelevant for fMRI
         expParam.data(seqi).currSeqStartTime = currSeqStartTime;
         
         % save PTB volume

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -11,17 +11,18 @@ end
 % make sure we got access to all the required functions and inputs
 addpath(genpath(fullfile(pwd, 'lib')))
 
-% Define the exp
-task = 'RhythmCategBlock'; % 'RhythmCategFT', 'PitchFT', 'RhythmCategBlock'
-
+% Define the task = 'RhythmCategFT', 'PitchFT', 'RhythmCategBlock'
 % Get parameters by providing task name, device and debugmode
-[cfg,expParam] = getParams(task,'scanner',0);
+[cfg,expParam] = getParams('RhythmCategBlock','scanner',0);
 
 % set and load all the subject input to run the experiment
 expParam = userInputs(cfg,expParam);
 expParam = createFilename(cfg,expParam);
 
-
+% create randomized sequence for 9 runs
+% run ==1 then it'll create 9 seq, otherwise it'll upload whats created
+[cfg,expParam] = makefMRISeqDesign(cfg,expParam);
+   
 % get time point at the beginning of the script (machine time)
 expParam.scriptStartTime = GetSecs();
 
@@ -49,9 +50,6 @@ try
     countFile  = saveEventsFile('open_stim', expParam,[],...
         'key_name','pressed','target');
     
-    
-    % get this exp related params
-    [cfg,expParam] = getBlockParameters(cfg,expParam);
     
     % Show instructions for fMRI task - modify to give duration and volume
     % check
@@ -86,78 +84,78 @@ try
     % wait for dummy fMRI scans
     WaitSecs(expParam.onsetDelay);
     
-
+    
     %% play sequences
-    for seqi = expParam.runNb %1:expParam.numSequences
+    %    for seqi = 1:expParam.numSequences
+    seqi = expParam.runNb;
+    % prep for BIDS saving structures
+    currSeq = struct();
+    responseEvents = struct();
+    
+    % construct sequence
+    currSeq = makeSequence(cfg,seqi);
+    
+    
+    % fill the buffer
+    PsychPortAudio('FillBuffer', cfg.pahandle, [currSeq.outAudio;currSeq.outAudio]);
+    
+    % start playing
+    currSeqStartTime = PsychPortAudio('Start', cfg.pahandle, cfg.PTBrepet,...
+        cfg.PTBstartCue, cfg.PTBwaitForDevice);
+    
+    % save params for later call in BIDS saving
+    expParam.seqi = seqi;
+    expParam.currSeqStartTime = currSeqStartTime;
+    
+    % ===========================================
+    % stimulus save for BIDS
+    % ===========================================
+    
+    % open a file to write sequencefor BIDS
+    currSeq(1).fileID = logFile.fileID;
+    
+    % adding columns in currSeq for BIDS format
+    for iPattern = 1:length(currSeq)
         
-        % prep for BIDS saving structures
-        currSeq = struct();
-        responseEvents = struct();
+        %correcting onsets for fMRI trigger onset
+        currSeq(iPattern,1).onset  = currSeq(iPattern,1).onset + ...
+            expParam.currSeqStartTime - expParam.experimentStart;
+        currSeq(iPattern,1).segmentOnset = currSeq(iPattern,1).segmentOnset...
+            + expParam.currSeqStartTime - expParam.experimentStart;
         
-        % construct sequence
-        currSeq = makeSequence(cfg,seqi);
-        
-        
-        % fill the buffer
-        PsychPortAudio('FillBuffer', cfg.pahandle, [currSeq.outAudio;currSeq.outAudio]);
-        
-        % start playing
-        currSeqStartTime = PsychPortAudio('Start', cfg.pahandle, cfg.PTBrepet,...
-            cfg.PTBstartCue, cfg.PTBwaitForDevice);
-        
-        % save params for later call in BIDS saving
-        expParam.seqi = seqi;
-        expParam.currSeqStartTime = currSeqStartTime;
-
-        % ===========================================
-        % stimulus save for BIDS
-        % ===========================================
-        
-        % open a file to write sequencefor BIDS
-        currSeq(1).fileID = logFile.fileID;
-        
-        % adding columns in currSeq for BIDS format
-        for iPattern = 1:length(currSeq)
-            
-            %correcting onsets for fMRI trigger onset
-            currSeq(iPattern,1).onset  = currSeq(iPattern,1).onset + ...
-                expParam.currSeqStartTime - expParam.experimentStart;
-            currSeq(iPattern,1).segmentOnset = currSeq(iPattern,1).segmentOnset...
-                + expParam.currSeqStartTime - expParam.experimentStart;
-            
-            %adding compulsory BIDS structures
-            currSeq(iPattern,1).trial_type  = 'dummy';
-            currSeq(iPattern,1).duration    = 0;
-            %
-            currSeq(iPattern,1).sequenceNum = seqi;
-            
-        end
-        
-        saveEventsFile('save', expParam, currSeq,'sequenceNum',...
-            'segmentNum','segmentOnset','stepNum','stepOnset','patternID',...
-            'segmCateg','F0','gridIOI','patternAmp','PE4','minPE4',...
-            'rangePE4','LHL24','minLHL24','rangeLHL24');
-
-        % ===========================================
-        % log everything into matlab structure
-        % ===========================================
-        
-        % save (machine) onset time for the current sequence
-        % might be irrelevant for fMRI
-        expParam.data(seqi).currSeqStartTime = currSeqStartTime;
-        
-        % save PTB volume
-        % might be irrelevant for fMRI
-        expParam.data(seqi).ptbVolume = PsychPortAudio('Volume',cfg.pahandle);
-        
-        % save current sequence information (without the audio, which can
-        % be easily resynthesized)
-        currSeq(1).outAudio = [];
-        expParam.data(seqi).seq = currSeq;
-        
+        %adding compulsory BIDS structures
+        currSeq(iPattern,1).trial_type  = 'dummy';
+        currSeq(iPattern,1).duration    = 0;
+        %
+        currSeq(iPattern,1).sequenceNum = seqi;
         
     end
-
+    
+    saveEventsFile('save', expParam, currSeq,'sequenceNum',...
+        'segmentNum','segmentOnset','stepNum','stepOnset','patternID',...
+        'segmCateg','F0','gridIOI','patternAmp','PE4','minPE4',...
+        'rangePE4','LHL24','minLHL24','rangeLHL24');
+    
+    % ===========================================
+    % log everything into matlab structure
+    % ===========================================
+    
+    % save (machine) onset time for the current sequence
+    % might be irrelevant for fMRI
+    expParam.data(seqi).currSeqStartTime = currSeqStartTime;
+    
+    % save PTB volume
+    % might be irrelevant for fMRI
+    expParam.data(seqi).ptbVolume = PsychPortAudio('Volume',cfg.pahandle);
+    
+    % save current sequence information (without the audio, which can
+    % be easily resynthesized)
+    currSeq(1).outAudio = [];
+    expParam.data(seqi).seq = currSeq;
+    
+    
+    %   end
+    
     
     %% Wait for audio and delays to catch up
     % wait while fMRI is ongoing

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -215,7 +215,7 @@ try
     
     %% wrapping up
     % last screen
-    if expParam.runNb == 666 %change this with the known final run#
+    if expParam.runNb == 666 && expParam.maxfMRIrun
         displayInstr('DONE. \n\n\nTHANK YOU FOR PARTICIPATING :)\n\n\n Soon we will take you out!',cfg);
     else
         displayInstr('This run is over. We will shortly start the following!',cfg);

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -50,6 +50,11 @@ try
         'key_name','pressed','target');
     
     
+    % % % modify this for fMRI needs
+    % instructions to set the volume
+    % displayInstr(expParam.trialDurInstruction,cfg,'setVolume');
+    % % % 
+    
     % Show instructions for fMRI task
     if expParam.fmriTask
         displayInstr(expParam.fmriTaskInst,cfg);

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -12,8 +12,8 @@ end
 addpath(genpath(fullfile(pwd, 'lib')))
 
 
-% Get parameters
-[cfg,expParam] = getParams('RhythmCategFT','scanner',1);
+% Get parameters by providing task name, device and debugmode
+[cfg,expParam] = getParams('RhythmCategFT','scanner',0);
 %[cfg,expParam] = getParams('RhythmCategBlock');
 %[cfg,expParam] = getParams('PitchFT');
 
@@ -50,14 +50,12 @@ try
         'key_name','pressed','target');
     
     
-    % % % modify this for fMRI needs
-    % instructions to set the volume
-    % displayInstr(expParam.trialDurInstruction,cfg,'setVolume');
-    % % % 
-    
-    % Show instructions for fMRI task
+    % Show instructions for fMRI task - modify to give duration and volume
+    % check
     if expParam.fmriTask
         displayInstr(expParam.fmriTaskInst,cfg);
+        % displayInstr(expParam.trialDurInstruction,cfg,'setVolume');
+
     end
     
     % wait for space key to be pressed by the experimenter
@@ -218,7 +216,7 @@ try
     
     %% wrapping up
     % last screen
-    if expParam.runNb == 666 || expParam.maxfMRIrun
+    if expParam.runNb == 666 || expParam.runNb == expParam.maxfMRIrun
         displayInstr('DONE. \n\n\nTHANK YOU FOR PARTICIPATING :)\n\n\n Soon we will take you out!',cfg);
     else
         displayInstr('This run is over. We will shortly start the following!',cfg);

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -13,14 +13,12 @@ addpath(genpath(fullfile(pwd, 'lib')))
 
 
 % Get parameters by providing task name, device and debugmode
-[cfg,expParam] = getParams('RhythmCategFT','scanner',0);
+[cfg,expParam] = getParams('RhythmCategBlock','scanner',0);
+%[cfg,expParam] = getParams('RhythmCategFT','scanner',0);
 %[cfg,expParam] = getParams('RhythmCategBlock');
 %[cfg,expParam] = getParams('PitchFT');
 
 
-% set and load all the subject input to run the experiment
-expParam = userInputs(cfg,expParam);
-expParam = createFilename(cfg,expParam);
 
 % get time point at the beginning of the script (machine time)
 expParam.scriptStartTime = GetSecs();

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -219,7 +219,7 @@ try
     
     %% wrapping up
     % last screen
-    if expParam.runNb == 666 || expParam.runNb == expParam.maxfMRIrun
+    if expParam.runNb == 666 || expParam.runNb == expParam.numSequences
         displayInstr('DONE. \n\n\nTHANK YOU FOR PARTICIPATING :)\n\n\n Soon we will take you out!',cfg);
     else
         displayInstr('This run is over. We will shortly start the following!',cfg);

--- a/fMRIMainExperiment.m
+++ b/fMRIMainExperiment.m
@@ -11,13 +11,15 @@ end
 % make sure we got access to all the required functions and inputs
 addpath(genpath(fullfile(pwd, 'lib')))
 
+% Define the exp
+task = 'RhythmCategBlock'; % 'RhythmCategFT', 'PitchFT', 'RhythmCategBlock'
 
 % Get parameters by providing task name, device and debugmode
-[cfg,expParam] = getParams('RhythmCategBlock','scanner',0);
-%[cfg,expParam] = getParams('RhythmCategFT','scanner',0);
-%[cfg,expParam] = getParams('RhythmCategBlock');
-%[cfg,expParam] = getParams('PitchFT');
+[cfg,expParam] = getParams(task,'scanner',0);
 
+% set and load all the subject input to run the experiment
+expParam = userInputs(cfg,expParam);
+expParam = createFilename(cfg,expParam);
 
 
 % get time point at the beginning of the script (machine time)
@@ -47,6 +49,9 @@ try
     countFile  = saveEventsFile('open_stim', expParam,[],...
         'key_name','pressed','target');
     
+    
+    % get this exp related params
+    [cfg,expParam] = getBlockParameters(cfg,expParam);
     
     % Show instructions for fMRI task - modify to give duration and volume
     % check
@@ -83,7 +88,7 @@ try
     
 
     %% play sequences
-    for seqi = 1:expParam.numSequences
+    for seqi = expParam.runNb %1:expParam.numSequences
         
         % prep for BIDS saving structures
         currSeq = struct();
@@ -158,7 +163,7 @@ try
     % wait while fMRI is ongoing
     % stay here till audio stops
     reachHereTime = (GetSecs - expParam.experimentStart);
-    audioDuration = (cfg.SequenceDur*expParam.numSequences);
+    audioDuration = (cfg.SequenceDur * expParam.numSeq4Run);
     
     % exp duration + delays - script reaching to till point
     WaitSecs(audioDuration + expParam.onsetDelay + expParam.endDelay ...

--- a/getParams.m
+++ b/getParams.m
@@ -176,9 +176,13 @@ elseif strcmp(expParam.task,'tapMainExp') || strcmp(expParam.task,'RhythmCategFT
     
     % get main experiment parameters
     [cfg,expParam] = getMainExpParameters(cfg,expParam);
+
+elseif strcmp(expParam.task,'RhythmCategBlock')
+    % get main experiment parameters
+    [cfg,expParam] = getBlockParameters(cfg,expParam);
     
+%elseif strcmp(expParam.task,'PitchFT')
     %other options to consider 
-    %[cfg,expParam] = getParams('RhythmCategBlock');
     %[cfg,expParam] = getParams('PitchFT');
     
 end

--- a/getParams.m
+++ b/getParams.m
@@ -1,4 +1,4 @@
-function [cfg,expParam] = getParams(task)
+function [cfg,expParam] = getParams(task,device,debugmode)
 % Initialize the parameters variables
 % Initialize the general configuration variables
 % =======
@@ -28,11 +28,11 @@ elseif IsLinux
 end
 
 %% Debug mode settings
-cfg.debug               = 1 ;  % To test the script with trasparent full size screen 
+cfg.debug               = debugmode ;  % To test the script with trasparent full size screen 
 expParam.verbose        = true; % add here and there some explanations with if verbose is ON. 
 
 %% MRI settings
-cfg.device        = 'scanner';       % 'PC': does not care about trigger(for behav) - otherwise use 'Scanner'
+cfg.device        = device;       % 'PC': does not care about trigger(for behav) - otherwise use 'Scanner'
 cfg.triggerKey    = 's';        % Set the letter sent by the trigger to sync stimulation and volume acquisition
 cfg.numTriggers   = 4;          % first #Triggers will be dummy scans
 cfg.eyeTracker    = false;      % Set to 'true' if you are testing in MRI and want to record ET data
@@ -172,10 +172,14 @@ if strcmp(expParam.task,'tapTraining')
     % get tapping training parameters
     [cfg,expParam] = getTrainingParameters(cfg,expParam);
     
-elseif strcmp(expParam.task,'tapMainExp')
+elseif strcmp(expParam.task,'tapMainExp') || strcmp(expParam.task,'RhythmCategFT')
     
     % get main experiment parameters
     [cfg,expParam] = getMainExpParameters(cfg,expParam);
+    
+    %other options to consider 
+    %[cfg,expParam] = getParams('RhythmCategBlock');
+    %[cfg,expParam] = getParams('PitchFT');
     
 end
 

--- a/getParams.m
+++ b/getParams.m
@@ -53,10 +53,6 @@ expParam.askGrpSess = [0 0];
 %esc key for both behav and fmri exp
 cfg.keyquit         = KbName('ESCAPE'); % press ESCAPE at response time to quit
 
-%% set and load all the subject input to run the experiment
-expParam = userInputs(cfg,expParam);
-expParam = createFilename(cfg,expParam);
-
 %% monitor
 % Monitor parameters - fMRI - CHANGE with fMRI parameters
 cfg.monitorWidth  	  = 42;  % Monitor Width in cm
@@ -134,16 +130,18 @@ expParam.pauseSeq = 1; % give a pause of below seconds in between sequences
 
 % define ideal number of sequences to be made
 % multiple of 3 is balanced design
-if strcmp(cfg.device,'pc')
+if strcmpi(cfg.device,'pc')
     expParam.numSequences = 6;
+    
     if cfg.debug
         expParam.numSequences = 2;
     end
-elseif strcmp(cfg.device,'scanner')
-    expParam.numSequences = 1;
-    if cfg.debug
-        expParam.numSequences = 2;
-    end
+    
+elseif strcmpi(cfg.device,'scanner')
+    
+    expParam.numSequences = 9;
+    expParam.numSeq4Run = 1; % for 1 run time calculation
+
 end
 
 
@@ -182,9 +180,9 @@ elseif strcmp(expParam.task,'tapMainExp') || strcmp(expParam.task,'RhythmCategFT
     % get main experiment parameters
     [cfg,expParam] = getMainExpParameters(cfg,expParam);
 
-elseif strcmp(expParam.task,'RhythmCategBlock')
-    % get main experiment parameters
-    [cfg,expParam] = getBlockParameters(cfg,expParam);
+% elseif strcmp(expParam.task,'RhythmCategBlock')
+%     % get main experiment parameters
+%     [cfg,expParam] = getBlockParameters(cfg,expParam);
     
 %elseif strcmp(expParam.task,'PitchFT')
     %other options to consider 

--- a/getParams.m
+++ b/getParams.m
@@ -111,6 +111,9 @@ cfg.audio.channels = 2;
 checkSoundFiles();
 
 %% Timing 
+
+% max fMRI run number
+expParam.maxfMRIrun = 9;
 % % %
 % convert waitSecs according to the TR = 2.28
 expParam.onsetDelay = 3 * 2.28; %Number of seconds before the rhythmic sequence (exp) are presented
@@ -128,10 +131,17 @@ expParam.pauseSeq = 1; % give a pause of below seconds in between sequences
 
 
 % define ideal number of sequences to be made
-if cfg.debug
-    expParam.numSequences = 2; % multiples of 3
-else
+% multiple of 3 is balanced design
+if strcmp(cfg.device,'pc')
     expParam.numSequences = 6;
+    if cfg.debug
+        expParam.numSequences = 2;
+    end
+elseif strcmp(cfg.device,'scanner')
+    expParam.numSequences = 3;
+    if cfg.debug
+        expParam.numSequences = 2;
+    end
 end
 
 

--- a/getParams.m
+++ b/getParams.m
@@ -154,7 +154,7 @@ end
 
 
 % max fMRI run number
-expParam.maxfMRIrun = 9;
+% expParam.maxfMRIrun = 9;
 % expParam.maxfMRIrun = expParam.numSequences;
 
 %% fMRI task

--- a/getParams.m
+++ b/getParams.m
@@ -1,4 +1,9 @@
 function [cfg,expParam] = getParams(task,device,debugmode)
+% NOTE: in order to use behav + fMRI with 1 getParams, we are using
+% getParam with 3 aguments so it won't interfere with behav script
+% CB edit 0n 09/07/2020
+
+
 % Initialize the parameters variables
 % Initialize the general configuration variables
 % =======
@@ -29,7 +34,7 @@ end
 
 %% Debug mode settings
 cfg.debug               = debugmode ;  % To test the script with trasparent full size screen 
-expParam.verbose        = true; % add here and there some explanations with if verbose is ON. 
+expParam.verbose        = 1; % add here and there some explanations with if verbose is ON. 
 
 %% MRI settings
 cfg.device        = device;       % 'PC': does not care about trigger(for behav) - otherwise use 'Scanner'
@@ -38,17 +43,17 @@ cfg.numTriggers   = 4;          % first #Triggers will be dummy scans
 cfg.eyeTracker    = false;      % Set to 'true' if you are testing in MRI and want to record ET data
 
 %% general configuration
+%for BIDS format: 
+expParam.task = task; % should be calling behav or fmri
+expParam.askGrpSess = [0 0]; % it won't ask you about group or session
+
 expParam.fmriTask = true; % the task is behav exp or fMRI? 
 
 % it'll only look for space press -
 % later on change with the responseBox indices/numbers! ! !
 expParam.responseKey = {'space'};
 
-%it should be calling behav or fmri - important for BIDS format.
-expParam.task = task;
 
-%it won't ask you about group or session
-expParam.askGrpSess = [0 0];
 
 %esc key for both behav and fmri exp
 cfg.keyquit         = KbName('ESCAPE'); % press ESCAPE at response time to quit
@@ -110,8 +115,6 @@ checkSoundFiles();
 
 %% Timing 
 
-% max fMRI run number
-expParam.maxfMRIrun = 9;
 % % %
 % convert waitSecs according to the TR = 2.28
 expParam.onsetDelay = 3 * 2.28; %Number of seconds before the rhythmic sequence (exp) are presented
@@ -132,18 +135,27 @@ expParam.pauseSeq = 1; % give a pause of below seconds in between sequences
 % multiple of 3 is balanced design
 if strcmpi(cfg.device,'pc')
     expParam.numSequences = 6;
-    
     if cfg.debug
         expParam.numSequences = 2;
     end
-    
+      
 elseif strcmpi(cfg.device,'scanner')
     
-    expParam.numSequences = 9;
-    expParam.numSeq4Run = 1; % for 1 run time calculation
+    if cfg.debug
+       expParam.numSequences = 1; % this param is for counterbalanced design
+    else
+        expParam.numSequences = 9;
+    end
+    
+    expParam.numSeq4Run = 1; % for an fMRI run time calculation
 
 end
 
+
+
+% max fMRI run number
+expParam.maxfMRIrun = 9;
+% expParam.maxfMRIrun = expParam.numSequences;
 
 %% fMRI task
 % if fmriTask == true, it'll display a fixation cross during the fMRI run
@@ -170,6 +182,8 @@ end
 
 
 %% more parameters to get according to the type of experiment
+% this part is solely for behavioral exp
+% control fMRI script has its getxxx.m instead of in here (getParam.m)
 if strcmp(expParam.task,'tapTraining')
     
     % get tapping training parameters
@@ -180,9 +194,9 @@ elseif strcmp(expParam.task,'tapMainExp') || strcmp(expParam.task,'RhythmCategFT
     % get main experiment parameters
     [cfg,expParam] = getMainExpParameters(cfg,expParam);
 
-% elseif strcmp(expParam.task,'RhythmCategBlock')
-%     % get main experiment parameters
-%     [cfg,expParam] = getBlockParameters(cfg,expParam);
+    elseif strcmp(expParam.task,'RhythmCategBlock')
+        % get main experiment parameters
+        [cfg,expParam] = getBlockParameters(cfg,expParam);
     
 %elseif strcmp(expParam.task,'PitchFT')
     %other options to consider 

--- a/getParams.m
+++ b/getParams.m
@@ -138,7 +138,7 @@ if strcmp(cfg.device,'pc')
         expParam.numSequences = 2;
     end
 elseif strcmp(cfg.device,'scanner')
-    expParam.numSequences = 3;
+    expParam.numSequences = 1;
     if cfg.debug
         expParam.numSequences = 2;
     end

--- a/getParams.m
+++ b/getParams.m
@@ -53,6 +53,9 @@ expParam.askGrpSess = [0 0];
 %esc key for both behav and fmri exp
 cfg.keyquit         = KbName('ESCAPE'); % press ESCAPE at response time to quit
 
+%% set and load all the subject input to run the experiment
+expParam = userInputs(cfg,expParam);
+expParam = createFilename(cfg,expParam);
 
 %% monitor
 % Monitor parameters - fMRI - CHANGE with fMRI parameters
@@ -69,7 +72,6 @@ cfg.textColor        = cfg.white;
 cfg.textFont         = 'Arial'; %'Courier New'
 cfg.textSize         = 30; %18
 %cfg.textStyle        = 1;
-
 
     
 %% sound levels
@@ -165,6 +167,9 @@ if expParam.fmriTask
     cfg.allCoords = [cfg.xCoords; cfg.yCoords];
     
 end
+
+
+
 
 %% more parameters to get according to the type of experiment
 if strcmp(expParam.task,'tapTraining')

--- a/getParams.m
+++ b/getParams.m
@@ -117,14 +117,14 @@ checkSoundFiles();
 
 % % %
 % convert waitSecs according to the TR = 2.28
-expParam.onsetDelay = 3 * 2.28; %Number of seconds before the rhythmic sequence (exp) are presented
-expParam.endDelay = 3 * 2.28; % Number of seconds after the end of all stimuli before ending the fmri run! 
+expParam.timing.onsetDelay = 3 * 2.28; %Number of seconds before the rhythmic sequence (exp) are presented
+expParam.timing.endDelay = 3 * 2.28; % Number of seconds after the end of all stimuli before ending the fmri run! 
 % % %
 
 % ending timings for fMRI
-expParam.endScreenDelay = 2; %end the screen after thank you screen
+expParam.timing.endScreenDelay = 2; %end the screen after thank you screen
 % delay for script ending
-expParam.endResponseDelay = 13; % wait for participant to response for counts
+expParam.timing.endResponseDelay = 13; % wait for participant to response for counts
 
 % these are for behavioral exp delays
 expParam.sequenceDelay = 1; %wait in between sequences? y/n

--- a/lib/getAllSeqDesign.m
+++ b/lib/getAllSeqDesign.m
@@ -1,4 +1,4 @@
-function res = getAllSeqDesign(categA,categB,cfg,expParam)
+function seqDesignFullExp = getAllSeqDesign(categA,categB,cfg,expParam)
 
 % this function designs the sequences for the whole experiment in a way
 % that the number of times each pattern is included is counterbalanced and
@@ -17,7 +17,7 @@ patterns2choose = [patterns2chooseA, patterns2chooseB];
 
 
 % allocate result with dimension: sequence x step x segm x pattern
-res = cell(expParam.numSequences, cfg.nStepsPerSequence, cfg.nSegmPerStep, cfg.nPatternPerSegment); 
+seqDesignFullExp = cell(expParam.numSequences, cfg.nStepsPerSequence, cfg.nSegmPerStep, cfg.nPatternPerSegment); 
 
 for seqi=1:expParam.numSequences
 
@@ -49,7 +49,7 @@ for seqi=1:expParam.numSequences
                 
                 % write pattern ID to the result
                 % dims: [seq x step x segm x pat]
-                res{seqi,stepi,segmi,pati} = chosenPatID; 
+                seqDesignFullExp{seqi,stepi,segmi,pati} = chosenPatID; 
 
                 % remove the picked pattern from the available pool
                 patterns2choose{segmi}(chosenPatIdx) = []; 

--- a/lib/getBlockParameters.m
+++ b/lib/getBlockParameters.m
@@ -1,4 +1,4 @@
-function     [cfg,expParam] = getMainExpParameters(cfg,expParam)
+function     [cfg,expParam] = getBlockParameters(cfg,expParam)
 % this function generates audio sequences to be played in the man
 % experiment
 
@@ -66,18 +66,19 @@ end
 % how many pattern cycles are within each step of [ABBB]
 % how many pattern in each segment A or B.
 cfg.nPatternPerSegment = 4;
-
+ 
 % if the gridIOI can vary across pattern cycles, we need to set the time 
 % interval between two successive segments to a fixed value (this must be 
 % greater or equal to the maximum possible segment duration)
 cfg.interSegmInterval = cfg.nPatternPerSegment * cfg.interPatternInterval; 
 
+
 % there can be a pause after all segments for category A are played 
 % (i.e. between A and B)
-cfg.delayAfterA = 0; 
+cfg.delayAfterA = cfg.interSegmInterval; 
 % there can be a pause after all segments for category B are played 
 % (i.e. between B and A)
-cfg.delayAfterB = 0; 
+cfg.delayAfterB = cfg.interSegmInterval;
 
 %% construct step [ABBB]
 % how many successive segments are presented for category A
@@ -86,7 +87,7 @@ cfg.nSegmentA = 1;
 
 % how many successive segments are presented for category B
 % manw many times segment B will be sequentially repeated
-cfg.nSegmentB = 3; 
+cfg.nSegmentB = 1; 
 
 % number of segments for each step
 cfg.nSegmPerStep = cfg.nSegmentB + cfg.nSegmentA; %4; 
@@ -164,29 +165,13 @@ cfg.patternComplex = getPatternInfo(grahnPatComplex, 'complex', cfg);
 % this is to make sure each pattern is used equal number of times in the
 % whole experiment
 
-% for exp like fmri that we will present 1 sequence per run, we are
-% creating full exp design in the first run and saving it for the other
-% runs to call .mat file
-
 cfg.labelCategA = 'simple'; 
 cfg.labelCategB = 'complex'; 
-
 %%%%%%%%%%%%
 % ! important, the order of arguments matters ! -> getAllSeq(categA, categB, ...)
 %%%%%%%%%%%%
+cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam); 
 
-if strcmp(cfg.device,'scanner')
-    if expParam.runNb == 1
-        DesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
-        save('SeqDesign','DesignFullExp');
-        cfg.seqDesignFullExp = DesignFullExp;
-    else
-        design = load('SeqDesign');
-        cfg.seqDesignFullExp = design.DesignFullExp;
-    end
-else
-    cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
-end
 
 %% generate example audio for volume setting
 % added F0s-amplitude because the relative dB set in volume adjustment in

--- a/lib/getBlockParameters.m
+++ b/lib/getBlockParameters.m
@@ -73,6 +73,7 @@ cfg.nPatternPerSegment = 4;
 cfg.interSegmInterval = cfg.nPatternPerSegment * cfg.interPatternInterval; 
 
 
+% Add delays for block's gap 
 % there can be a pause after all segments for category A are played 
 % (i.e. between A and B)
 cfg.delayAfterA = cfg.interSegmInterval; 
@@ -80,7 +81,7 @@ cfg.delayAfterA = cfg.interSegmInterval;
 % (i.e. between B and A)
 cfg.delayAfterB = cfg.interSegmInterval;
 
-%% construct step [ABBB]
+%% construct step [A_B_]
 % how many successive segments are presented for category A
 % manw many times segment A will be sequentially repeated
 cfg.nSegmentA = 1; 
@@ -170,8 +171,20 @@ cfg.labelCategB = 'complex';
 %%%%%%%%%%%%
 % ! important, the order of arguments matters ! -> getAllSeq(categA, categB, ...)
 %%%%%%%%%%%%
-cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam); 
 
+% ADD EVEN?ODD RUNS STARTING WITH A OR B CATEG!!!
+if strcmp(cfg.device,'scanner')
+    if expParam.runNb == 1
+        DesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
+        save('SeqDesign','DesignFullExp');
+        cfg.seqDesignFullExp = DesignFullExp;
+    else
+        design = load('SeqDesign');
+        cfg.seqDesignFullExp = design.DesignFullExp;
+    end
+else
+    cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
+end
 
 %% generate example audio for volume setting
 % added F0s-amplitude because the relative dB set in volume adjustment in

--- a/lib/getBlockParameters.m
+++ b/lib/getBlockParameters.m
@@ -170,9 +170,6 @@ cfg.labelCategA = 'simple';
 cfg.labelCategB = 'complex'; 
 
 
-%Now we create a function instead of the below line
-%cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
-
 %% generate example audio for volume setting
 % added F0s-amplitude because the relative dB set in volume adjustment in
 % PychPortAudio will be used in the mainExp

--- a/lib/getBlockParameters.m
+++ b/lib/getBlockParameters.m
@@ -168,23 +168,10 @@ cfg.patternComplex = getPatternInfo(grahnPatComplex, 'complex', cfg);
 
 cfg.labelCategA = 'simple'; 
 cfg.labelCategB = 'complex'; 
-%%%%%%%%%%%%
-% ! important, the order of arguments matters ! -> getAllSeq(categA, categB, ...)
-%%%%%%%%%%%%
 
-% ADD EVEN?ODD RUNS STARTING WITH A OR B CATEG!!!
-if strcmp(cfg.device,'scanner')
-    if expParam.runNb == 1
-        DesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
-        save('SeqDesign','DesignFullExp');
-        cfg.seqDesignFullExp = DesignFullExp;
-    else
-        design = load('SeqDesign');
-        cfg.seqDesignFullExp = design.DesignFullExp;
-    end
-else
-    cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
-end
+
+%Now we create a function instead of the below line
+%cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
 
 %% generate example audio for volume setting
 % added F0s-amplitude because the relative dB set in volume adjustment in
@@ -200,57 +187,13 @@ cfg.volumeSettingSound = repmat(makeStimMainExp(ones(1,16), cfg,...
 % fMRI instructions
 expParam.fmriTaskInst = ['Fixate to the cross & count the deviant tone\n \n\n'];
 
-
-
-
-% behavioral instructions
-
-loadPathInstr = fullfile('lib','instr','mainExp'); 
-
-% -------------------
-% intro instructions
-% -------------------
-% These need to be saved in separate files, named: 'instrMainExpIntro#'
-% The text in each file will be succesively (based on #) displayed on 
-% the screen at the begining of the experiment. Every time, the script 
-% will wait for a keypress. 
-
-dirInstr = dir(fullfile(loadPathInstr,'instrMainExpIntro*')); 
-expParam.introInstruction = cell(1,length(dirInstr)); 
-for i=1:length(dirInstr)
-    instrFid = fopen(fullfile(loadPathInstr, dirInstr(i).name),'r','n','UTF-8'); 
-    while ~feof(instrFid)
-        expParam.introInstruction{i} = [expParam.introInstruction{i}, fgets(instrFid)]; 
-    end
-    fclose(instrFid); 
-end
-
-% ------------------------
-% general task instructions
-% ------------------------
-% This is a general summary of the instructions. Participants can toggle
-% these on the screen between sequences if they forget, or want to make
-% sure they understand their task. 
-
-dirInstr = dir(fullfile(loadPathInstr,'instrMainExpGeneral')); 
-expParam.generalInstruction = ''; 
-instrFid = fopen(fullfile(loadPathInstr, dirInstr.name),'r','n','UTF-8'); 
-while ~feof(instrFid)
-    expParam.generalInstruction = [expParam.generalInstruction, fgets(instrFid)]; 
-end
-fclose(instrFid); 
-
-
-
 % ------------------------------------------------
 % instruction showing info about sequence curation 
 % ------------------------------------------------
 
 expParam.trialDurInstruction = [sprintf('Trial duration will be: %.1f minutes\n\n',cfg.SequenceDur/60), ...
                             'Set your volume now. \n\n\nThen start the experiment whenever ready...\n\n']; 
-    
-
-                        
+                           
 % ------------------------------
 % sequence-specific instructions
 % ------------------------------
@@ -261,27 +204,8 @@ expParam.generalDelayInstruction = ['The %d out of %d is over!\n\n', ...
                             'Good luck!\n\n']; 
 
 
-% For each sequence, there can be additional instructions. 
-% Save as text file with name: 'instrMainExpDelay#', 
-% where # is the index of the sequence after which the
-% instruction should appear. 
 
-dirInstr = dir(fullfile(loadPathInstr,'instrMainExpDelay*')); 
-expParam.seqSpecificDelayInstruction = cell(1, expParam.numSequences); 
-for i=1:length(dirInstr)
-    
-    targetSeqi = regexp(dirInstr(i).name, '(?<=instrMainExpDelay)\d*', 'match'); 
-    targetSeqi = str2num(targetSeqi{1}); 
-    instrFid = fopen(fullfile(loadPathInstr, dirInstr(i).name),'r','n','UTF-8'); 
-    while ~feof(instrFid)
-        expParam.seqSpecificDelayInstruction{targetSeqi} = [expParam.seqSpecificDelayInstruction{i}, fgets(instrFid)]; 
-    end
-    fclose(instrFid); 
-end
-
-
-
-    
+  
 end
 
 

--- a/lib/makeSequence.m
+++ b/lib/makeSequence.m
@@ -2,6 +2,11 @@ function seq = makeSequence(cfg,seqi,varargin)
 % This function constructs a stimulus sequence.
 % by using makeStimMainExp.m script
 
+% it's also using getAllSeqDesign.m to get the (counterbalanced) 
+% order of the patterns with the given run number==seqi (fmri) or
+% expParam.numSequences == seqi (behav)
+
+
 % ------
 % INPUT
 % ------

--- a/lib/makefMRISeqDesign.m
+++ b/lib/makefMRISeqDesign.m
@@ -15,8 +15,11 @@ function [cfg,expParam] = makefMRISeqDesign(cfg,expParam)
 %%%%%%%%%%%%
 % ! important, the order of arguments matters ! -> getAllSeq(categA, categB, ...)
 %%%%%%%%%%%%
+%getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
 
-% ADD EVEN/ODD RUNS STARTING WITH A OR B CATEG!!!
+
+
+% ADD SHUFFLE ORDER FOR STARTING WITH A OR B CATEG for BLOCK DESING ! 
 
 % CREATE counterbalanced sequences for every 3 sequence then multiply with
 % 3 (in case they stop fMRI, or we want ot increase to 12 runs)
@@ -34,9 +37,6 @@ if strcmp(cfg.device,'scanner')
 else
     cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
 end
-
-
-
 
 
 end

--- a/lib/makefMRISeqDesign.m
+++ b/lib/makefMRISeqDesign.m
@@ -1,0 +1,42 @@
+function [cfg,expParam] = makefMRISeqDesign(cfg,expParam)
+
+ % this function creates counterbalanced audio sequences for fMRI in 
+ % by using subfunction as:
+ % makeSequecen.m
+ % getAllSeqDesign.m
+ % makeStimMainExp.m
+ 
+ % In the future it can be embedded into getParams.m script but since it's
+ % depending on the expParam.runNb parameter, it should be causiously
+ % embedded. (e.g. after the script gets runNb)
+
+ 
+ %% Get counterbalanced sequences according to the total fMRI RUNs
+%%%%%%%%%%%%
+% ! important, the order of arguments matters ! -> getAllSeq(categA, categB, ...)
+%%%%%%%%%%%%
+
+% ADD EVEN/ODD RUNS STARTING WITH A OR B CATEG!!!
+
+% CREATE counterbalanced sequences for every 3 sequence then multiply with
+% 3 (in case they stop fMRI, or we want ot increase to 12 runs)
+% expParam.numSequences = 3
+
+if strcmp(cfg.device,'scanner')
+    if expParam.runNb == 1
+        DesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
+        save('SeqDesign','DesignFullExp');
+        cfg.seqDesignFullExp = DesignFullExp;
+    else
+        design = load('SeqDesign');
+        cfg.seqDesignFullExp = design.DesignFullExp;
+    end
+else
+    cfg.seqDesignFullExp = getAllSeqDesign(cfg.patternSimple, cfg.patternComplex, cfg, expParam);
+end
+
+
+
+
+
+end

--- a/tapMainExperiment.m
+++ b/tapMainExperiment.m
@@ -13,7 +13,7 @@ addpath(genpath(fullfile(pwd, 'lib')))
 
 
 % Get parameters by providing task name, device and debugmode
-[cfg,expParam] = getParams('tapMainExp','pc',1);
+[cfg,expParam] = getParams('tapMainExp','pc',0);
 
 % set and load all the subject input to run the experiment
 expParam = userInputs(cfg,expParam);

--- a/tapMainExperiment.m
+++ b/tapMainExperiment.m
@@ -13,7 +13,7 @@ addpath(genpath(fullfile(pwd, 'lib')))
 
 
 % Get parameters by providing task name, device and debugmode
-[cfg,expParam] = getParams('tapMainExp','pc',0);
+[cfg,expParam] = getParams('tapMainExp','pc',1);
 
 % set and load all the subject input to run the experiment
 expParam = userInputs(cfg,expParam);

--- a/tapMainExperiment.m
+++ b/tapMainExperiment.m
@@ -12,8 +12,8 @@ end
 addpath(genpath(fullfile(pwd, 'lib')))
 
 
-% Get parameters
-[cfg,expParam] = getParams('tapMainExp');
+% Get parameters by providing task name, device and debugmode
+[cfg,expParam] = getParams('tapMainExp','pc',0);
 
 % set and load all the subject input to run the experiment
 expParam = userInputs(cfg,expParam);
@@ -62,7 +62,7 @@ try
 
 
     % if there's wait time,..wait
-    WaitSecs(expParam.onsetDelay);
+    WaitSecs(2); %expParam.onsetDelay
     
     
     

--- a/tapTrainer.m
+++ b/tapTrainer.m
@@ -21,10 +21,9 @@ tic
 % make sure we got access to all the required functions and inputs
 addpath(genpath(fullfile(pwd, 'lib')))
 
-% % % refactor this part to run training + exp within 1 go?
-% parameters
-[cfg,expParam] = getParams('tapTraining'); 
-% % % 
+% Get parameters by providing task name, device and debugmode
+[cfg,expParam] = getParams('tapTraining','pc',0); 
+
 
 % datalogging structure
 datalog = []; 


### PR DESCRIPTION
in fMRIMainExperiment.m the block design option is added.
getAllSeqDesign.m is untouched due to using the expParam.numSequence parameter. But additional makefMRISeqDesign.m generated. It's used for generating whole fmri exp sequence counterbalancing. If runNb ==1, it created counterbalanced design and saves as .mat file. In the following runs, it's loading the .mat for keeping the counterbalancing.

Additionally, due to no for loop in fMRI exp, (1 script run == 1 run == 1 sequence to be played), the debug mode is useless. If debug mode wants to be used, it needs to be reviewed/generated.

Next issue to do: shuffle the starting order for categA/categB in the block design. And of course, adding the task.